### PR TITLE
swiper

### DIFF
--- a/style.css
+++ b/style.css
@@ -637,6 +637,22 @@ td{
 }
 
 
+.swiper-container .inner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    z-index: 50
+}
+
+.swiper-container .swiper-slide img {
+    max-width: 100%;
+    height: 100%;
+    object-fit: cover
+}
+
+
 
 @media screen and (max-width:767px) {
  .wrapper{


### PR DESCRIPTION
まず文字が薄かったのは、画像の下に来ていたからで、
z-index使って上に持ってきました。

画像の左側が暗かったのはうまくレスポンシブ できてなくて、
隣のスライドと重なってたから！
画像の大きさを100％に指定することで重なりを防いだよ。